### PR TITLE
Added JSON support to the Data Reader class

### DIFF
--- a/4900Project/Assets/BackupData/TestFile.json
+++ b/4900Project/Assets/BackupData/TestFile.json
@@ -1,0 +1,4 @@
+{
+	"IsATest": true,
+	"Name": "Google Drive"
+}

--- a/4900Project/Assets/BackupData/TestFile.json.meta
+++ b/4900Project/Assets/BackupData/TestFile.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b3b76b1a00e75fd46beaf3b9f71506f1
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/4900Project/Assets/Scenes/DataReading/DataReadingScene.unity
+++ b/4900Project/Assets/Scenes/DataReading/DataReadingScene.unity
@@ -306,6 +306,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1277997623}
   - component: {fileID: 1277997622}
+  - component: {fileID: 1277997624}
   m_Layer: 0
   m_Name: GameObject
   m_TagString: Untagged
@@ -339,3 +340,15 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1277997624
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1277997621}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e9559b5c2fcf204418cfa79ee220196e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/4900Project/Assets/Scripts/Data/Files/FileConstants.cs
+++ b/4900Project/Assets/Scripts/Data/Files/FileConstants.cs
@@ -15,7 +15,6 @@ namespace FileConstants
     {
         public string GoogleDriveFileId;
         public string LocalBackupFile;
-        public string MimeType;
     }
 
     /// <summary>
@@ -27,40 +26,42 @@ namespace FileConstants
         public static readonly FileStorageData Dialog = new FileStorageData()
         {
             GoogleDriveFileId = "1_7nd016Df8DQaQcoTO5uVkwkHLHL_RIIVejc0AGOE_U",
-            LocalBackupFile = $"{Application.dataPath}/BackupData/Dialog.csv",
-            MimeType = "text/csv"
+            LocalBackupFile = $"{Application.dataPath}/BackupData/Dialog.csv"
         };
 
         // Items CSV
         public static readonly FileStorageData Items = new FileStorageData()
         {
             GoogleDriveFileId = "1FfBoXktnMt-L44RBr4YOiQFztfTFeJVKOX56EC_FxjE",
-            LocalBackupFile = $"{Application.dataPath}/BackupData/Items.csv",
-            MimeType = "text/csv"
+            LocalBackupFile = $"{Application.dataPath}/BackupData/Items.csv"
         };
 
         // Town CSV
         public static readonly FileStorageData Town = new FileStorageData()
         {
             GoogleDriveFileId = "1elPXxNyDorlGKN-1HzR7sPzJIHzNZAtes3FTixTM94s",
-            LocalBackupFile = $"{Application.dataPath}/BackupData/Town.csv",
-            MimeType = "text/csv"
+            LocalBackupFile = $"{Application.dataPath}/BackupData/Town.csv"
         };
 
         // Tutorial CSV
         public static readonly FileStorageData Tutorial = new FileStorageData()
         {
             GoogleDriveFileId = "1BB_AqHnOiwcTCAZ9qmOwC-Xm_faD2HiLYtrkgmK1LMA",
-            LocalBackupFile = $"{Application.dataPath}/BackupData/Tutorial.csv",
-            MimeType = "text/csv"
+            LocalBackupFile = $"{Application.dataPath}/BackupData/Tutorial.csv"
         };
 
         // Note: For testing purposes only - test CSV
-        public static readonly FileStorageData TestFile = new FileStorageData()
+        public static readonly FileStorageData TestCsv = new FileStorageData()
         {
             GoogleDriveFileId = "1i_W43TDJLPjL08V7knEnVfbeZonzHhXc5CED3fact8g",
-            LocalBackupFile = $"{Application.dataPath}/BackupData/TestFile.csv",
-            MimeType = "text/csv"
+            LocalBackupFile = $"{Application.dataPath}/BackupData/TestFile.csv"
+        };
+
+        // Test JSON - for testing only
+        public static readonly FileStorageData TestJson = new FileStorageData()
+        {
+            GoogleDriveFileId = "1yY_mL1qKoD1ROQCB1Zr3aH2UcxHNWrqg",
+            LocalBackupFile = $"{Application.dataPath}/BackupData/TestFile.json"
         };
 
         // Files list - used for creating backups.
@@ -71,7 +72,8 @@ namespace FileConstants
             Files.Items,
             Files.Town,
             Files.Tutorial,
-            Files.TestFile
+            Files.TestCsv,
+            Files.TestJson
         };
     }
 }

--- a/4900Project/Assets/Scripts/Data/Files/LoadCsvTest.cs
+++ b/4900Project/Assets/Scripts/Data/Files/LoadCsvTest.cs
@@ -16,9 +16,9 @@ public class LoadCsvTest : MonoBehaviour
 {
     // Start is called before the first frame update
     void Start()
-    { 
+    {
         // Load in all the data
-        GameData.LoadCsv<Foo>(Files.TestFile, out IEnumerable<Foo> result);
+        GameData.LoadCsv<Foo>(Files.TestCsv, out IEnumerable<Foo> result);
 
         // Outputs all the data in the logs
         var resultString = new System.Text.StringBuilder();

--- a/4900Project/Assets/Scripts/Data/Files/LoadJsonTest.cs
+++ b/4900Project/Assets/Scripts/Data/Files/LoadJsonTest.cs
@@ -1,0 +1,33 @@
+﻿using FileConstants;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace Assets.Scenes.DataReadingScene
+{
+    /// <summary>
+    /// A simple class. This will be constructed from the test JSON file.
+    /// </summary>
+    [Serializable]
+    class FooJson
+    {
+        public bool IsATest;
+        public string Name;
+    }
+
+    /// <summary>
+    /// The test class for loading in JSON. Should output "IsATest: true with Name Google Drive"
+    /// </summary>
+    class LoadJsonTest : MonoBehaviour
+    {
+        void Start()
+        {
+            GameData.LoadJson<FooJson>(Files.TestJson, out FooJson result);
+            Debug.Log($"Received a result of IsATest: {result.IsATest} with Name {result.Name}");
+            Debug.Log($"JSON Test passed: {result.IsATest && result.Name == "Google Drive"}");
+        }
+    }
+}

--- a/4900Project/Assets/Scripts/Data/Files/LoadJsonTest.cs.meta
+++ b/4900Project/Assets/Scripts/Data/Files/LoadJsonTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e9559b5c2fcf204418cfa79ee220196e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## What am I addressing?
closes #69 

## How/Why did I address it?
The DataReader class now has two primary methods:
- LoadCsv<T>(FileStorageData fileData, out IEnumerable<T> data) (this is the same as before)
- LoadJson<T>(FileStorageData fileData, out T data) (this is the new method)

The LoadJson method can be called to load in a JSON document. It works the same way as we've been running with CSVs - create the FileStorageData reference and pass that in, and it'll return the result in a class marked by the out parameter. Difference is this one works to map out JSON (using the JsonUtility class from Unity) so we'll be able to use that for future development.

I also added a new test, named LoadJsonTest, which will load in a test JSON document, output some data from that, and then print a little message along with it indicating whether the test succeeded or passed. Ideally I'd like to wrap this into some actual unit testing, which I'll get done this weekend in a separate PR (along with some other changes, like moving this stuff out into the Scripts folder and deleting this scene entirely). 

## Reviewers
@GameDevProject-S20/bestteam

### What should reviewers focus on?
- [x] Try to load in a JSON document; did it load in all the data? Is it easy to use?

## Comments & Concerns 
This goes with the same system that I had before, so there's a good amount of documentation up for it already in our wiki. I'm going to be updating that over the next little bit to make sure it's all up-to-date with using JSON, but let me know if there's any questions that stand out in the Discord so I can give quick answers on that