### PR TITLE
[WIP] F/92 travel mechanics

### DIFF
--- a/4900Project/Assets/Scripts/Data/DataTracker.cs
+++ b/4900Project/Assets/Scripts/Data/DataTracker.cs
@@ -38,9 +38,9 @@ public class DataTracker : MonoBehaviour
         WorldMap = OverworldMapLoader.LoadMap();
         ShopManager.LoadData();
         TownManager.LoadData();
-        Player.Inventory.weightLimit = 10000000f;
+        Player.Inventory.weightLimit = 150f;
         Player.Inventory.AddItem("Rations", 8);
-        Player.Inventory.AddItem("Fuel", 20);
+        Player.Inventory.AddItem("Fuel", 35);
         Player.Inventory.AddItem("Fresh Fruit", 1);
         Player.Inventory.AddItem("Scrap Metal", 6);
         Player.Inventory.AddItem("Wrench", 1);

--- a/4900Project/Assets/Scripts/Inventory/Inventory.cs
+++ b/4900Project/Assets/Scripts/Inventory/Inventory.cs
@@ -39,7 +39,25 @@ public class Inventory
         }
         return Mathf.Min(capacity, amount);
     }
-    
+
+
+    /// <summary>
+    /// Returns the weight class of the inventory
+    /// </summary>
+    /// <returns>weight class, 3 for heavy, 2 for normal, 1 for light.</returns>
+    public int WeightClass() {
+        float howFull = TotalWeight()/weightLimit;
+        Debug.Log("howfull=" + howFull);
+        if (howFull > 0.7f) 
+        {
+            return 3;
+        }
+        else if(howFull > 0.3f) 
+        {
+            return 2;
+        }
+        return 1;
+    }
 
     /// <summary>
     /// Removes an item from the inventory

--- a/4900Project/Assets/Scripts/Items/ItemManager.cs
+++ b/4900Project/Assets/Scripts/Items/ItemManager.cs
@@ -138,7 +138,7 @@ public class ItemManager : MonoBehaviour
         tempList = new List<typetag>();
         tempList.Add(typetag.Medicine);
         tempList.Add(typetag.Luxury);
-        temp = new Item("Medical Kit", "High end First Aid Kit for dangerous work", "NOt only stocked iwth the best medical supplies on hand, but even contain stimulants and boosters to avoid injury in the first place", 20, 2, tempList);
+        temp = new Item("Medical Kit", "High end First Aid Kit for dangerous work", "NOt only stocked with the best medical supplies on hand, but even contain stimulants and boosters to avoid injury in the first place", 20, 2, tempList);
         itemsMaster.Add(temp.DisplayName, temp);
     }
 

--- a/4900Project/Assets/Scripts/OverworldMap/OverworldMapUI.cs
+++ b/4900Project/Assets/Scripts/OverworldMap/OverworldMapUI.cs
@@ -121,9 +121,45 @@ public class OverworldMapUI : MonoBehaviour
                 MapNode selected = hit.collider.gameObject.GetComponent<MapNode>();
                 if (DataTracker.Current.WorldMap.HasEdge(selected.nodeID, DataTracker.Current.currentLocationId))
                 {
-                    targetNode = selected;
-                    targetPos = hit.collider.gameObject.transform.position;
-                    isTravelling = true;
+                    
+                    int weightClass = DataTracker.Current.Player.Inventory.WeightClass();
+                    Debug.Log(DataTracker.Current.Player.Inventory.weightLimit);
+                    Debug.Log(weightClass);
+
+                    int fuel = DataTracker.Current.Player.Inventory.Contains("Fuel");
+                    //will be done with percent of max capacity later, just testing with constants for now
+                    int fuelrate;
+                    int dayrate;
+                    if (weightClass == 3) {
+                        fuelrate = 3;
+                        dayrate = 2;
+                    } else if (weightClass == 2) {
+                        fuelrate = 2;
+                        dayrate = 1;
+                    } else {
+                        fuelrate = 1;
+                        dayrate = 1;
+                    }
+
+                    Debug.Log("Weight=" + DataTracker.Current.Player.Inventory.TotalWeight());
+                    Debug.Log("Traveling here will take " + dayrate + " day(s) and " + fuelrate + " fuel"); //example weight-fuel/time rates: below 30% max weight = 1 fuel 1 day, 31-100% weight = 2 fuel 1 day, >100% = 3 fuel 2 days
+                    Debug.Log("Current fuel: " + fuel);
+                    Debug.Log("Current day: " + DataTracker.Current.dayCount);
+                    Debug.Log("You will have " + (fuel - fuelrate) + " fuel left after traveling here");
+                    Debug.Log("It will be day " + (DataTracker.Current.dayCount + dayrate) + " after traveling here");
+
+                    if (fuel - fuelrate > 0) {
+
+                        DataTracker.Current.Player.Inventory.RemoveItem("Fuel", fuelrate);
+                        DataTracker.Current.dayCount += dayrate;
+
+                        targetNode = selected;
+                        targetPos = hit.collider.gameObject.transform.position;
+                        isTravelling = true;
+                    } else 
+                    {
+                        Debug.Log("You're out of fuel! On the bright side not only will the scavengers get a good payday from your remains, but you'll serve as a good reminder to always check the tanks before leaving port\nGAME OVER");
+                    }
 
                 }
             }

--- a/4900Project/ProjectSettings/QualitySettings.asset
+++ b/4900Project/ProjectSettings/QualitySettings.asset
@@ -95,7 +95,7 @@ QualitySettings:
     skinWeights: 2
     textureQuality: 0
     anisotropicTextures: 1
-    antiAliasing: 2
+    antiAliasing: 0
     softParticles: 0
     softVegetation: 1
     realtimeReflectionProbes: 1


### PR DESCRIPTION
## What am I addressing?
#92 

## How/Why did I address it?
Added fuel and weight thresholds (will be changed to % later, for now just arbitrary flat values (cutoffs at 30 and 60 weight))
player can no longer move if they cannot afford the travel cost
days are just a counter (eg no year/month/day as of yet)
travelling to node is RIGHT click, left click will log fuel/time cost incurred for traveling to the node. Swapped it because left seemed like default for the player so it made more sense to me to show them info before they travel, but it can we swapped back if people don't like it



## Reviewers
@GameDevProject-S20/bestteam
### What should reviewers focus on?
{help guide the reviewers for what to look for -- what do you need their opinion on?}
- [x] reviewed
- [ ] not reviewed

## Comments & Concerns 
If I have a minute during lunch tomorrow I'll add a text box for the info currently being logged so it's accessible during gameplay. I was a dumbass and deleted it all tonight.
