### PR TITLE
Add Variety of Quests

### DIFF
--- a/4900Project/Assets/Scripts/Events/EventManager.cs
+++ b/4900Project/Assets/Scripts/Events/EventManager.cs
@@ -29,9 +29,11 @@ namespace SIEvents
 
         public Events.Transaction.Event OnTransaction = new Events.Transaction.Event();
 
-        //=== Town ===================================================//
+        //=== Map ===================================================//
 
-        public Events.Town.EnterEvent OnTownEnter = new Events.Town.EnterEvent();
+        public Events.Map.TownEnter OnTownEnter = new Events.Map.TownEnter();
+
+        public Events.Map.MapNodeVisit onNodeVisit = new Events.Map.MapNodeVisit();
 
         //=== Quest ==================================================//
 

--- a/4900Project/Assets/Scripts/Events/Events.cs
+++ b/4900Project/Assets/Scripts/Events/Events.cs
@@ -44,10 +44,13 @@ namespace SIEvents
             }
         }
 
-        public partial class Town
+        public partial class Map 
         {
             [System.Serializable]
-            public class EnterEvent : UnityEvent<Town> { };
+            public class TownEnter : UnityEvent<Town> { };
+
+            [System.Serializable]
+            public class MapNodeVisit : UnityEvent<OverworldMap.LocationNode> { };
         }
 
         public partial class Dialogue

--- a/4900Project/Assets/Scripts/OverworldMap/OverworldMapUI.cs
+++ b/4900Project/Assets/Scripts/OverworldMap/OverworldMapUI.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
 using UnityEngine.SceneManagement;
+using SIEvents;
 
 
 public class OverworldMapUI : MonoBehaviour
@@ -86,7 +87,10 @@ public class OverworldMapUI : MonoBehaviour
                     DataTracker.Current.currentLocationId = selected;
                     targetPos = hit.collider.gameObject.transform.position;
                     OverworldMap.LocationNode node;
+
                     if (DataTracker.Current.WorldMap.GetNode(selected, out node)){
+                        DataTracker.Current.EventManager.onNodeVisit.Invoke(node); 
+
                         if (node.Type == OverworldMap.LocationType.TOWN){
                             enterNodeButton.interactable = true;
                         }
@@ -102,6 +106,10 @@ public class OverworldMapUI : MonoBehaviour
     }
 
     public void OnButtonClick(){
+        var node = DataTracker.Current.GetCurrentNode();
+        Town town = DataTracker.Current.TownManager.GetTownById(node.LocationId);
+        if (node.Type == OverworldMap.LocationType.TOWN)
+            DataTracker.Current.EventManager.OnTownEnter.Invoke(town);
         SceneManager.LoadScene("Town");
     }
 

--- a/4900Project/Assets/Scripts/Quests/Quest.cs
+++ b/4900Project/Assets/Scripts/Quests/Quest.cs
@@ -366,6 +366,41 @@ namespace Quests
         }
     }
 
+    public class VisitCondition : Condition
+    {
+        //Potentially have a targetType, and use this Condition to visit either any specific town, or any specific type of town.
+        OverworldMap.LocationNode target;
+        private UnityAction<OverworldMap.LocationNode> visitAction;
+        public VisitCondition(string _description, OverworldMap.LocationNode targetNode)
+         : base(_description)
+        {
+            target = targetNode;
+        }
+
+        public override void AllowProgression()
+        {
+            visitAction = new UnityAction<OverworldMap.LocationNode>((OverworldMap.LocationNode target) => Handler(target));
+            EventManager.Instance.onNodeVisit.AddListener(visitAction);
+        }
+
+        public override void DisallowProgression()
+        {
+            EventManager.Instance.onNodeVisit.RemoveListener(visitAction);
+        }
+        protected virtual void Handler(OverworldMap.LocationNode location)
+        {
+            if (target.Id == location.Id)
+            {
+                Satisfy();
+            }
+        }
+
+        public override string ToString()
+        {
+            return string.Format("Condition: {0}, visit node {1} is {3}.", Description, target, (IsSatisfied ? "satisfied" : "not satisfied"));
+        }
+    }
+
     public class DialogueCondition : Condition
     {
         string ButtonText;


### PR DESCRIPTION
## What am I addressing?
Issue #95 involves designing a variety of Quests for the player to experience.

## How/Why did I address it?
I started to address it by conceptualizing a series of conditions that will be reasonably easy to implement based on our existing systems.
I wanted to check how reasonably easy they were, so I started Implementing one of them. (MapNodeVisited Event). The Implementation is straightforwards.

Here are some Quest Conditions that can act as building blocks. Nouns (Data objects) in the conditions can either be identified by a unique identifier, or by category. (Specific or General)

- Find the closest town that specializes in an item category
- Find a specific town
- Find a specific person to talk to
- Find a specific item, (buy it) 
- Find a specific item under a certain price threshold
- Trade a specific/general item to/from a specific/general person
- Find a specific piece of dialogue belonging to a character.
- Find this node, resolve the node's encounter.

Here are some Quests built from these conditions.

### The Northern Trade Coalition
**A member of a merchant's coalition (Bill Burr) is recruiting freelance merchants to cut down on competition. They offer the player cheap fuel prices if they can prove themselves as capable merchants.**
  - First the player has to find a specific item that is at least as cheap as 70% of their baseline cost.
  - The player has to buy that item
  - The player returns to the recruiter

The recruiter then will buy the items off you for full price, which goes towards funding the next quest.

### The Initiation
**The recruiter says the real test is now at hand. The player has to find and acquire a very rare item and bring it back. (To make the quest more challenging, we may temporarily hold onto the player's funds, except for the money that they made from the previous quest)**
  - The player has to find a specific rare item
  - The player has to buy that rare item
  - The player has to return to the recruiter

### Henderson's Guilt
**You learn after your initiation that there is unrest in the coalition's governing bureau. Existing members want to grab dirt on the member Andrew Henderson, who they believe is embezzling their stockpiled resources for his own personal prosperity. Because you are a new recruit, your face is unknown to A. Henderson, and you are offered a mission to travel to York and investigate a paper trail that Burr has collected.**
- The player has to travel to York
- The player has to find a specific piece of dialogue belonging to one of the characters in York that hints A. Henderson may be engaged in an affair.
- The player has to talk to A. Henderson. With the new information, dialogue opens up where Henderson admits to the affair, and states the money trail leads towards his payments towards a blackmail. He then proves he hasn't embezzled any of the stock.
- The player returns to Burr for a reward.

## Reviewers
@GameDevProject-S20/bestteam
### What should reviewers focus on?
Do not focus on the code changes. They are just there to experiment before implementation occurs in the next sprint.
- [ ] Is there enough variety to these Quests?
- [ ] Do these Quests appropriately leverage our underlying systems?
- [ ] Do you foresee any of these quests being difficult to balance or write for?

## Comments & Concerns 
**Potential user story**
After taking on this issue. I feel like Quests would benefit from having an optional reference to a character in the game that can act as the Quest granter.
When this reference is present, the Quest will have an extra stage tacked onto the end which is "Return to {Quest Giver's Location} and talk to {Quest Giver's name here}".
This offers an in-game Quest hand-in method that can be easily added or removed from a Quest based on designer's preference or context.