### PR TITLE
Dialogue resizing fix

### DIFF
--- a/4900Project/Assets/Resources/Prefabs/Dialogue/DialogueCanvas.prefab
+++ b/4900Project/Assets/Resources/Prefabs/Dialogue/DialogueCanvas.prefab
@@ -139,13 +139,13 @@ MonoBehaviour:
   m_margin: {x: 0, y: 0, z: 0, w: 0}
   m_textInfo:
     textComponent: {fileID: 8016332630339876201}
-    characterCount: 111
+    characterCount: 0
     spriteCount: 0
-    spaceCount: 18
-    wordCount: 19
+    spaceCount: 0
+    wordCount: 0
     linkCount: 0
-    lineCount: 5
-    pageCount: 1
+    lineCount: 0
+    pageCount: 0
     materialCount: 1
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
@@ -434,10 +434,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_UiScaleMode: 0
+  m_UiScaleMode: 1
   m_ReferencePixelsPerUnit: 100
   m_ScaleFactor: 1
-  m_ReferenceResolution: {x: 800, y: 600}
+  m_ReferenceResolution: {x: 1024, y: 768}
   m_ScreenMatchMode: 0
   m_MatchWidthOrHeight: 0
   m_PhysicalUnit: 3
@@ -935,7 +935,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 106.4}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &8016332631041560895
 CanvasRenderer:
@@ -988,11 +988,11 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_IgnoreLayout: 0
   m_MinWidth: -1
-  m_MinHeight: -1
+  m_MinHeight: 106.4
   m_PreferredWidth: -1
   m_PreferredHeight: -1
   m_FlexibleWidth: 1
-  m_FlexibleHeight: 1
+  m_FlexibleHeight: -1
   m_LayoutPriority: 1
 --- !u!114 &8016332631041560890
 MonoBehaviour:
@@ -1241,7 +1241,7 @@ MonoBehaviour:
   m_ChildForceExpandWidth: 1
   m_ChildForceExpandHeight: 1
   m_ChildControlWidth: 1
-  m_ChildControlHeight: 0
+  m_ChildControlHeight: 1
   m_ChildScaleWidth: 0
   m_ChildScaleHeight: 1
 --- !u!1 &8016332631449703287
@@ -2023,7 +2023,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 425.6}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &8016332632141809270
 CanvasRenderer:


### PR DESCRIPTION
## What am I addressing?
Fixes a bug that I found in the Dialogue system. Used to be that the heights of things were fixed, so the Dialogue would look weird if the screen resolution was off. Everything scales nicely now.

## How/Why did I address it?
Updated the Dialogue prefab:
- Canvas is set to scale with screen size
- Buttons are set to 106.4 and should be fixed to that
- Dialogue window (the actual text & avatar display) will resize according to how much additional room there is

## Reviewers
@GameDevProject-S20/bestteam

### What should reviewers focus on?
- [ ] Try to play around with the screen resolution, verify that it updates correctly

## Comments & Concerns 
