### PR TITLE
Add a try-catch block around the Google Drive API calls

### DIFF
--- a/4900Project/Assets/Scripts/Data/Files/GameData.cs
+++ b/4900Project/Assets/Scripts/Data/Files/GameData.cs
@@ -177,14 +177,20 @@ public class GameData
         result = new MemoryStream();
 
         // Download the file into our result stream
-        var export = googleDrive.Files.Get(fileId);
-        var response = export.DownloadWithStatus(result);
+        try
+        {
+            var export = googleDrive.Files.Get(fileId);
+            var response = export.DownloadWithStatus(result);
 
-        // Note: Once the data is written to the stream, the stream position will be set to the end
-        // We want to reset this to the start so that data can be read
-        result.Seek(0, SeekOrigin.Begin);
+            // Note: Once the data is written to the stream, the stream position will be set to the end
+            // We want to reset this to the start so that data can be read
+            result.Seek(0, SeekOrigin.Begin);
 
-        // Return whether or not the request worked
-        return response.Status != Google.Apis.Download.DownloadStatus.Failed;
+            // Return whether or not the request worked
+            return response.Status != Google.Apis.Download.DownloadStatus.Failed;
+        } catch (Exception)
+        {
+            return false;
+        }
     }
 }


### PR DESCRIPTION
## What am I addressing?

## How/Why did I address it?
Adds a try-catch around the Google Drive API which should help in case any errors come along in future builds - if an exception is thrown it'll just skip past and go into using the backup file

## Reviewers
@GameDevProject-S20/bestteam
### What should reviewers focus on?
{help guide the reviewers for what to look for -- what do you need their opinion on?}
- [x] reviewed
- [ ] not reviewed

## Comments & Concerns 
There may be a bigger issue for CSVs, so it may be worth tossing a spike in to investigate that. JSON seems to be loading fine but it can't load CSVs from Google Drive.