### PR TITLE
Adds tweaks to camera that make it usable in game

### DIFF
--- a/4900Project/Assets/Scenes/Map/MapScene.unity
+++ b/4900Project/Assets/Scenes/Map/MapScene.unity
@@ -482,7 +482,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2b3d1e9b9a2054649a759f352026d791, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  panSpeed: 1
+  panSpeed: 0.1
   zoomSpeed: 4
   max: {x: 4.68, y: 8, z: 6.54}
   min: {x: -4.68, y: 4, z: -6.54}

--- a/4900Project/Assets/Scripts/OverworldMap/MapDisplay/SimpleCameraController.cs
+++ b/4900Project/Assets/Scripts/OverworldMap/MapDisplay/SimpleCameraController.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 public class SimpleCameraController : MonoBehaviour
 {
     [SerializeField]
-    float panSpeed = 1.0f;
+    float panSpeed = 0.1f;
     [SerializeField]
     float zoomSpeed = 4.0f;
     [SerializeField]
@@ -14,7 +14,7 @@ public class SimpleCameraController : MonoBehaviour
     Vector3 min;
 
 
-    float panBorderSize = 6;
+    float panBorderSize = 20;
 
     private Vector3 lastMousePosition = Vector3.zero;
     private bool mouseJustClicked = false;
@@ -22,6 +22,7 @@ public class SimpleCameraController : MonoBehaviour
 
     private void Update() 
     {
+        transform.position =  GeneralPurposeControl(transform.position);
         transform.position = MousePanControl(transform.position);
         transform.position = MouseScrollControl(transform.position);
     }
@@ -40,6 +41,7 @@ public class SimpleCameraController : MonoBehaviour
         }
             return nextPosition;
     }
+
     public Vector3 MousePanControl(Vector3 position)
     {
         float verticalBorder = Screen.width/panBorderSize;


### PR DESCRIPTION
## What am I addressing?
A quick fix to the camera settings, that I had missed when merging the camera feature.

I had forgotten that even if I update the default fields of a monobehaviour script, any instances of that monobehaviour on a game object remains unchanged. I had to reset the component to update the changes from the script.
