### PR TITLE
F/146/music fade

### DIFF
--- a/4900Project/Assets/Scenes/StartMenu/BackroundMusic.cs
+++ b/4900Project/Assets/Scenes/StartMenu/BackroundMusic.cs
@@ -20,8 +20,8 @@ public class BackroundMusic : MonoBehaviour
     private float finalVolume;
     private float volumeFadeStep;
 
-    private float playTime;
-    private float silenceTime;
+    private float playTime = 0;
+    private float silenceTime = 0;
 
     // Start is called before the first frame update
     void Start()


### PR DESCRIPTION
## What am I addressing?
closes #146 

## How/Why did I address it?
Adds methods that allow the volume to be faded in and out. These can be called manually to fade to a desired volume. Right now I have made it so the volume fades to silence every few minutes for a few seconds, to give a little break from the music, then starts back up again.

## Reviewers
@GameDevProject-S20/bestteam
### What should reviewers focus on?
You should notice the fading in/out when testing the game. The time interval for playing music is pretty long (1-3 minutes), so if you just want to test this feature you might wanna change the values in BackgroundMusic::InitSongPlayTime().
- [x] Looks good

## Comments & Concerns 
N/a