### PR TITLE
Google Drive CSV Fix

### DIFF
--- a/4900Project/Assets/Scripts/Data/Files/FileConstants.cs
+++ b/4900Project/Assets/Scripts/Data/Files/FileConstants.cs
@@ -15,6 +15,7 @@ namespace FileConstants
     {
         public string GoogleDriveFileId;
         public string LocalBackupFile;
+        public string MimeType;
     }
 
     /// <summary>
@@ -26,49 +27,56 @@ namespace FileConstants
         public static readonly FileStorageData Dialog = new FileStorageData()
         {
             GoogleDriveFileId = "1_7nd016Df8DQaQcoTO5uVkwkHLHL_RIIVejc0AGOE_U",
-            LocalBackupFile = $"{Application.streamingAssetsPath}/BackupData/Dialog.csv"
+            LocalBackupFile = $"{Application.streamingAssetsPath}/BackupData/Dialog.csv",
+            MimeType = "text/csv"
         };
 
         // Items CSV
         public static readonly FileStorageData Items = new FileStorageData()
         {
             GoogleDriveFileId = "1zT5RKm-cFOMkGjg3OQwewlrfC3SuKmbwk1d7Ei1juuA",
-            LocalBackupFile = $"{Application.streamingAssetsPath}/BackupData/Items.csv"
+            LocalBackupFile = $"{Application.streamingAssetsPath}/BackupData/Items.csv",
+            MimeType = "text/csv"
         };
 
         // Town CSV
         public static readonly FileStorageData Town = new FileStorageData()
         {
             GoogleDriveFileId = "1elPXxNyDorlGKN-1HzR7sPzJIHzNZAtes3FTixTM94s",
-            LocalBackupFile = $"{Application.streamingAssetsPath}/BackupData/Town.csv"
+            LocalBackupFile = $"{Application.streamingAssetsPath}/BackupData/Town.csv",
+            MimeType = "text/csv"
         };
 
         // Tutorial CSV
         public static readonly FileStorageData Tutorial = new FileStorageData()
         {
             GoogleDriveFileId = "1BB_AqHnOiwcTCAZ9qmOwC-Xm_faD2HiLYtrkgmK1LMA",
-            LocalBackupFile = $"{Application.streamingAssetsPath}/BackupData/Tutorial.csv"
+            LocalBackupFile = $"{Application.streamingAssetsPath}/BackupData/Tutorial.csv",
+            MimeType = "text/csv"
         };
 
         // json list of strings
         public static readonly FileStorageData MapNodes = new FileStorageData()
         {
             GoogleDriveFileId = "1b1C8UP12nCt-iiDYuMc3kQePnF-iLi_7bjDVvu7_2mA",
-            LocalBackupFile = $"{Application.streamingAssetsPath}/BackupData/MapNodes.csv"
+            LocalBackupFile = $"{Application.streamingAssetsPath}/BackupData/MapNodes.csv",
+            MimeType = "text/csv"
         };
 
         // json list of classes
         public static readonly FileStorageData MapEdges = new FileStorageData()
         {
             GoogleDriveFileId = "1AENRNM6BTT52Vu0uAsx8bfJUlDVi6LDNIlzMLOAQZnM",
-            LocalBackupFile = $"{Application.streamingAssetsPath}/BackupData/MapEdges.csv"
+            LocalBackupFile = $"{Application.streamingAssetsPath}/BackupData/MapEdges.csv",
+            MimeType = "text/csv"
         };
 
         // Note: For testing purposes only - test CSV
         public static readonly FileStorageData TestCsv = new FileStorageData()
         {
             GoogleDriveFileId = "1i_W43TDJLPjL08V7knEnVfbeZonzHhXc5CED3fact8g",
-            LocalBackupFile = $"{Application.streamingAssetsPath}/BackupData/Tests/TestFile.csv"
+            LocalBackupFile = $"{Application.streamingAssetsPath}/BackupData/Tests/TestFile.csv",
+            MimeType = "text/csv"
         };
 
         // JSON Tests
@@ -76,21 +84,24 @@ namespace FileConstants
         public static readonly FileStorageData TestBasicJson = new FileStorageData()
         {
             GoogleDriveFileId = "10gaDHRTOs9TX3XkQQpcj5jYK_jxTGeSw",
-            LocalBackupFile = $"{Application.streamingAssetsPath}/BackupData/Tests/BasicJson.json"
+            LocalBackupFile = $"{Application.streamingAssetsPath}/BackupData/Tests/BasicJson.json",
+            MimeType = "application/json"
         };
 
         // json list of strings
         public static readonly FileStorageData TestJsonStringsList = new FileStorageData()
         {
             GoogleDriveFileId = "1FJSW9lSejV3_TO0tHCc951GVdbN1YnYS",
-            LocalBackupFile = $"{Application.streamingAssetsPath}/BackupData/Tests/StringList.json"
+            LocalBackupFile = $"{Application.streamingAssetsPath}/BackupData/Tests/StringList.json",
+            MimeType = "application/json"
         };
 
         // json list of classes
         public static readonly FileStorageData TestJsonListOfClass = new FileStorageData()
         {
             GoogleDriveFileId = "1YMCwaA60aDROG_ipxJjl8GF4c-mpQwMl",
-            LocalBackupFile = $"{Application.streamingAssetsPath}/BackupData/Tests/ListOfClass.json"
+            LocalBackupFile = $"{Application.streamingAssetsPath}/BackupData/Tests/ListOfClass.json",
+            MimeType = "application/json"
         };
 
         // Files list - used for creating backups.

--- a/4900Project/Assets/Unit Testing/DataReaderTests.cs
+++ b/4900Project/Assets/Unit Testing/DataReaderTests.cs
@@ -11,11 +11,28 @@ namespace Tests
     public class DataReaderTests : GameData
     {
         // Test Classes - These are used to store the data
-        [Serializable]
         protected class TestClass
         {
             public int Id;
             public string Name;
+        }
+        [Serializable]
+        protected class TestCsvClass : TestClass
+        {
+            public new int Id
+            {
+                get { return base.Id; }
+                set { base.Id = value; }
+            }
+            public new string Name
+            {
+                get { return base.Name; }
+                set { base.Name = value; }
+            }
+        }
+        [Serializable]
+        protected class TestJsonClass : TestClass
+        { 
         }
 
         [Serializable]
@@ -34,7 +51,7 @@ namespace Tests
         [Serializable]
         protected class JsonClassesList
         {
-            public List<TestClass> List;
+            public List<TestJsonClass> List;
         }
 
         /// <summary>
@@ -44,8 +61,8 @@ namespace Tests
         public void TestCsvReading()
         {
 
-            GameData.LoadCsv<TestClass>(Files.TestCsv, out IEnumerable<TestClass> results);
-            VerifyTestClassList(results);
+            GameData.LoadCsv<TestCsvClass>(Files.TestCsv, out IEnumerable<TestCsvClass> results);
+            VerifyTestClassList<TestCsvClass>(results);
         }
 
         /// <summary>
@@ -104,7 +121,7 @@ namespace Tests
         [Test]
         public void CanReadJsonFromGoogleDrive()
         {
-            var canRead = GameData.DownloadFileFromGoogleDrive(Files.TestBasicJson.GoogleDriveFileId, out _);
+            var canRead = GameData.DownloadFileFromGoogleDrive(Files.TestBasicJson.GoogleDriveFileId, Files.TestBasicJson.MimeType, out _);
             Assert.IsTrue(canRead, "Failed to read the JSON data.");
         }
 
@@ -114,7 +131,7 @@ namespace Tests
         [Test]
         public void CanReadCsvFromGoogleDrive()
         {
-            var canRead = GameData.DownloadFileFromGoogleDrive(Files.TestCsv.GoogleDriveFileId, out _);
+            var canRead = GameData.DownloadFileFromGoogleDrive(Files.TestCsv.GoogleDriveFileId, Files.TestCsv.MimeType, out _);
             Assert.IsTrue(canRead, "Failed to load CSV data from Google Drive.");
         }
 
@@ -123,7 +140,7 @@ namespace Tests
         /// with the values matching what's expected (first - Id 1, Name Google; second - Id 2, Name Drive)
         /// </summary>
         /// <param name="testClassList"></param>
-        protected void VerifyTestClassList(IEnumerable<TestClass> testClassList)
+        protected void VerifyTestClassList<T>(IEnumerable<T> testClassList) where T : TestClass
         {
             // Should have two results
             Assert.AreEqual(2, testClassList.Count(), $"The results count {testClassList.Count()} did not match the expected count of 2.");
@@ -139,7 +156,7 @@ namespace Tests
         /// <param name="csvData"></param>
         /// <param name="expectedId"></param>
         /// <param name="expectedName"></param>
-        protected void VerifyCsvContents(TestClass csvData, int expectedId, string expectedName)
+        protected void VerifyCsvContents<T>(T csvData, int expectedId, string expectedName) where T : TestClass
         {
             // Assert that the ID matches
             Assert.AreEqual(expectedId, csvData.Id, $"The data's ID {csvData.Id} did not match our expected ID of {expectedId}.");


### PR DESCRIPTION
## What am I addressing?
No issue associated with this one

## How/Why did I address it?
With the JSON update to reading Google Drive, I changed the Export method call to a Get method call.
This works fine for JSON, but doesn't let the system read CSV - so every CSV call was failing and reverting to the backup.
This change now checks what type of file you're trying to load (based on the MimeType of the file) and calls to the method needed for that type (CSVs use export, JSON uses get).

Re-ran the tests & everything is working with this one.

## Reviewers
@GameDevProject-S20/bestteam

### What should reviewers focus on?
- [ ] Play through the game, verify that this doesn't break anything for loading data

## Comments & Concerns 
