### PR TITLE
Adds Region class to towns

### DIFF
--- a/4900Project/Assets/Scripts/Inventory/Inventory.cs
+++ b/4900Project/Assets/Scripts/Inventory/Inventory.cs
@@ -99,7 +99,7 @@ public class Inventory
             float valueModifier = 1;
             foreach (typetag itemTag in ItemManager.Current.itemsMaster[item.Key].tags)
             {
-                foreach (KeyValuePair<typetag, float> modify in TownManager.Instance.GetCurrentTownData().valueModifiers)
+                foreach (KeyValuePair<typetag, float> modify in TownManager.Instance.GetCurrentTownData().reg.valueModifiers)
                 {
                     if (itemTag == modify.Key)
                     {

--- a/4900Project/Assets/Scripts/Town/Town.cs
+++ b/4900Project/Assets/Scripts/Town/Town.cs
@@ -20,6 +20,7 @@ public class Town
 
     public List<int> shops;
     public Dictionary<typetag, float> valueModifiers;
+    public Region reg;
 
     public Town(int Id, string Name, string Leader, string Colour="#FFFF5E0")
     {
@@ -29,7 +30,7 @@ public class Town
         this.Colour = Colour;
         shops = new List<int>();
         tags = new List<typetag>();
-        valueModifiers = new Dictionary<typetag, float>();
+        reg = new Region();
 
         // Randomly Select an Icon
         // Do not select the ugly ones
@@ -85,5 +86,15 @@ public class Town
                 break;
             }
         }
+    }
+}
+
+public class Region
+{
+    public Dictionary<typetag, float> valueModifiers;
+
+    public Region()
+    {
+        valueModifiers = new Dictionary<typetag, float>(); ;
     }
 }

--- a/4900Project/Assets/Scripts/Town/TownManager.cs
+++ b/4900Project/Assets/Scripts/Town/TownManager.cs
@@ -24,6 +24,7 @@ public class TownManager
     }
 
     private Dictionary<int, Town> towns = new Dictionary<int, Town>();
+    private List<Region> regions = new List<Region>();
 
     private TownManager()
     {
@@ -55,7 +56,10 @@ public class TownManager
         towns[4].AddShop(8);
         towns[4].AddShop(9);
 
-        towns[1].valueModifiers.Add(typetag.Medicine, 0.25f);
+        Region tempy = new Region();
+        tempy.valueModifiers.Add(typetag.Medicine, 0.25f);
+        regions.Add(tempy);
+        towns[1].reg = regions[0];
     }
 
     public IEnumerable<Town> GetTownEnumerable()


### PR DESCRIPTION
## What am I addressing?
messes with already closed 144

## How/Why did I address it?
Simply adds a region class that contains the value modifiers for towns and has townmanager keep a region list and remaining code is modified to work with new location.  This means towns can be grouped by region with the same modifiers

## Reviewers
@GameDevProject-S20/bestteam
### What should reviewers focus on?
-Does it still work?
- [x] reviewed
- [x] not reviewed

## Comments & Concerns 
