### PR TITLE
Camera fix

### DIFF
--- a/4900Project/Assets/Scripts/OverworldMap/MapDisplay/SimpleCameraController.cs
+++ b/4900Project/Assets/Scripts/OverworldMap/MapDisplay/SimpleCameraController.cs
@@ -93,7 +93,7 @@ public class SimpleCameraController : MonoBehaviour
     {
         Vector3 nextPosition = position;
 
-        nextPosition.y += Input.mouseScrollDelta.y * zoomSpeed;
+        nextPosition.y -= Input.mouseScrollDelta.y * zoomSpeed;
         nextPosition.y = Mathf.Clamp(nextPosition.y, min.y, max.y);
 
         return nextPosition;


### PR DESCRIPTION
## What am I addressing?
Closes #187 

## How/Why did I address it?
I added an additional check to see if the player's mouse is in the upper region of the screen (menu). If so, the hover area to trigger panning is decreased significantly. All menu buttons can now be accessed without shifting the camera.

I also reversed the zoom/scroll directions, like Connor requested.

## Reviewers
@GameDevProject-S20/bestteam

### What should reviewers focus on?
- [ ] Run the game, try using the menu buttons & scrolling

## Comments & Concerns 
¯\_(ツ)_/¯
