### PR TITLE
Fixed tooltip to work again in shop after inventory changes

### DIFF
--- a/4900Project/Assets/Scenes/Inventory/ShopScene.unity
+++ b/4900Project/Assets/Scenes/Inventory/ShopScene.unity
@@ -2585,6 +2585,7 @@ MonoBehaviour:
   LegendaryImage: {fileID: 21300000, guid: 0951ad93e6ddd8d4b9c2646f267cde4e, type: 3}
   Portrait: {fileID: 952109235}
   IconMissing: {fileID: 21300000, guid: 48a2031da6891144d8449a2bc8034e9a, type: 3}
+  tooltip: {fileID: 1798132577}
 --- !u!224 &1438724943 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 1840571253241227794, guid: 73267574d9da8a94e9ee4d58fbda672a,
@@ -3271,6 +3272,18 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 7494ceec3b7d4df4b8392a3d3d3a12dc, type: 3}
+--- !u!114 &1798132577 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2396775854986234161, guid: 7494ceec3b7d4df4b8392a3d3d3a12dc,
+    type: 3}
+  m_PrefabInstance: {fileID: 1798132576}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67e462b1cd2e2364290dd242dc62484c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1803618799
 GameObject:
   m_ObjectHideFlags: 0

--- a/4900Project/Assets/Scripts/Inventory/InventoryWindow.cs
+++ b/4900Project/Assets/Scripts/Inventory/InventoryWindow.cs
@@ -62,6 +62,7 @@ public class InventoryWindow : MonoBehaviour
             listItem.transform.Find("Icon").GetComponent<Image>().sprite = ItemManager.Current.itemsMaster[item.Key].Icon;
             listItem.transform.SetParent(playerInventoryObject, false);
             listItem.name = ItemManager.Current.itemsMaster[item.Key].DisplayName + "_button";
+            listItem.GetComponent<HoverBehaviour>().tooltip = tooltip;
             itemObjects.Add(listItem);
         }
     }

--- a/4900Project/Assets/Scripts/Inventory/Trading.cs
+++ b/4900Project/Assets/Scripts/Inventory/Trading.cs
@@ -63,6 +63,8 @@ public class Trading : MonoBehaviour
     GameObject Portrait;
     [SerializeField]
     Sprite IconMissing;
+    [SerializeField]
+    public Tooltip tooltip;
 
     public void Start() {
         shop = ShopManager.Instance.GetShopById(DataTracker.Current.currentShopId);
@@ -96,6 +98,7 @@ public class Trading : MonoBehaviour
         listItem.transform.SetParent(parent, false);
         listItem.GetComponent<Button>().onClick.AddListener(onClick);
         listItem.name = ItemManager.Current.itemsMaster[itemName].DisplayName + "_button";
+        listItem.GetComponent<HoverBehaviour>().tooltip = tooltip;
     }
 
     void buildShopList(){

--- a/4900Project/Assets/Scripts/Tooltip/HoverBehaviour.cs
+++ b/4900Project/Assets/Scripts/Tooltip/HoverBehaviour.cs
@@ -7,11 +7,11 @@ using TMPro;
 
 public class HoverBehaviour : MonoBehaviour, IPointerClickHandler, IPointerEnterHandler, IPointerExitHandler
 {
-    private Tooltip tooltip;
+    public Tooltip tooltip;
 
     void Awake()
     {
-        tooltip = InventoryWindow.Instance.tooltip;
+        //tooltip = InventoryWindow.Instance.tooltip;
     }
 
     public void OnPointerClick(PointerEventData eventData)


### PR DESCRIPTION
## What am I addressing?
Fixes tooltip bug in shop

## How/Why did I address it?
Shop and inventory now both have places to find the tooltip rather than locking it to either one.
## Reviewers
@GameDevProject-S20/bestteam

### What should reviewers focus on?
- [ ] Check out inventory and shop 
- [ ] Make sure that tooltip works 


