### PR TITLE
Update Jounal UI to fix bug with getting the wrong content GameObject

### DIFF
--- a/4900Project/Assets/Scenes/Map/MapScene.unity
+++ b/4900Project/Assets/Scenes/Map/MapScene.unity
@@ -268,6 +268,11 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: -0.000697955
       objectReference: {fileID: 0}
+    - target: {fileID: 8124421194925567599, guid: 0c786e4fb3f4640e2b0cc9b1cd57a3b8,
+        type: 3}
+      propertyPath: m_Name
+      value: Quest List Content
+      objectReference: {fileID: 0}
     - target: {fileID: 8124421195123670588, guid: 0c786e4fb3f4640e2b0cc9b1cd57a3b8,
         type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -2126,6 +2131,26 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 7107254858817221932, guid: ae75890649c1d4cfdaddce00cf03f31d,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7107254858817221932, guid: ae75890649c1d4cfdaddce00cf03f31d,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7107254858817221932, guid: ae75890649c1d4cfdaddce00cf03f31d,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7107254858817221932, guid: ae75890649c1d4cfdaddce00cf03f31d,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 7199653088097753765, guid: e8e0713c01c44684db4ab4c34a0a47e2,
         type: 3}
       propertyPath: m_AnchorMin.y
@@ -2624,26 +2649,6 @@ PrefabInstance:
     - target: {fileID: 7864621162552622781, guid: e8e0713c01c44684db4ab4c34a0a47e2,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7107254858817221932, guid: ae75890649c1d4cfdaddce00cf03f31d,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7107254858817221932, guid: ae75890649c1d4cfdaddce00cf03f31d,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7107254858817221932, guid: ae75890649c1d4cfdaddce00cf03f31d,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7107254858817221932, guid: ae75890649c1d4cfdaddce00cf03f31d,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []

--- a/4900Project/Assets/Scripts/Quests/QuestJournalWindow.cs
+++ b/4900Project/Assets/Scripts/Quests/QuestJournalWindow.cs
@@ -23,7 +23,7 @@ public class QuestJournalWindow : MonoBehaviour
         NameField = GameObject.Find("Quest Name").GetComponent<UnityEngine.UI.Text>();
         DescriptionField = GameObject.Find("Description").GetComponent<UnityEngine.UI.Text>();
         TaskField = GameObject.Find("Task Text").GetComponent<UnityEngine.UI.Text>();
-        QuestCollection = GameObject.Find("Content");
+        QuestCollection = GameObject.Find("Quest List Content");
 
         // Load QuestItem resource
         QuestItem = Resources.Load<GameObject>("Prefabs/Quest/Item");

--- a/4900Project/ProjectSettings/QualitySettings.asset
+++ b/4900Project/ProjectSettings/QualitySettings.asset
@@ -95,7 +95,7 @@ QualitySettings:
     skinWeights: 2
     textureQuality: 0
     anisotropicTextures: 1
-    antiAliasing: 0
+    antiAliasing: 2
     softParticles: 0
     softVegetation: 1
     realtimeReflectionProbes: 1


### PR DESCRIPTION
## What am I addressing?
A bug where a button would appear in the dialogue after opening the quest journal. 

## How/Why did I address it?
I updated the Quest Journal Prefab to change the GameObject "Content" to "Quest List Content" to avoid conflicts. This was updated in the map scene as well as the QuestJournalWindow.cs file. 


## Reviewers
@GameDevProject-S20/bestteam

### What should reviewers focus on?
- [ ] Check out the scene map, open the journal after getting the first quest. 

