### PR TITLE
Fix the GUI Ordering issue we found in the play test

### DIFF
--- a/4900Project/Assets/Scenes/HudNavMenu/HudActions.cs
+++ b/4900Project/Assets/Scenes/HudNavMenu/HudActions.cs
@@ -8,6 +8,7 @@ using DG.Tweening;
 
 public class HudActions : MonoBehaviour
 {
+    protected GameObject activeObject;
 
     Events.QuestEvents.QuestManagerUpdated questChangedEvent;
     bool helpPanelOpened = false;
@@ -21,28 +22,54 @@ public class HudActions : MonoBehaviour
     }
     public void OnInventoryButtonClick()
     {
-        GameObject.Find("Map").GetComponent<OverworldMapUI>().InventoryCanvas.SetActive(true);
+        ActivateInterface(GameObject.Find("Map").GetComponent<OverworldMapUI>().InventoryCanvas);
         EventManager.Instance.FreezeMap.Invoke();
 
     }
 
     public void OnMenuButtonClick()
     {
+        DeactivateInterface();
         EventManager.Instance.EscapeMenuRequested.Invoke();
     }
 
     public void OnJournalButtonClick()
     {
-        GameObject.Find("Map").GetComponent<OverworldMapUI>().QuestJournalCanvas.SetActive(true); 
+        ActivateInterface(GameObject.Find("Map").GetComponent<OverworldMapUI>().QuestJournalCanvas);
         GameObject.Find("questjournal").GetComponent<UnityEngine.UI.RawImage>().material = default;
         EventManager.Instance.FreezeMap.Invoke();
-
     }
 
     public void QuestChangedHandler()
     {
        Material glowing = Resources.Load<Material>("Materials/Glowing");
        GameObject.Find("questjournal").GetComponent<UnityEngine.UI.RawImage>().material = Instantiate(glowing);
+    }
+
+    /// <summary>
+    /// Deactivates all opened interfaces.
+    /// </summary>
+    protected void DeactivateInterface()
+    {
+        if (activeObject != null)
+        {
+            activeObject.SetActive(false);
+        }
+
+        // Tell the Escape Menu to close
+        DataTracker.Current.EventManager.EscapeMenuCloseRequested.Invoke();
+    }
+
+    /// <summary>
+    /// Activates a new interface. Closes the past one if one was open.
+    /// </summary>
+    /// <param name="interfaceCanvas"></param>
+    protected void ActivateInterface(GameObject interfaceCanvas)
+    {
+        DeactivateInterface();
+
+        interfaceCanvas.SetActive(true);
+        activeObject = interfaceCanvas;
     }
 
     public void OnToggleView(){

--- a/4900Project/Assets/Scripts/EscapeMenu/Frontend/EscapeMenuControl.cs
+++ b/4900Project/Assets/Scripts/EscapeMenu/Frontend/EscapeMenuControl.cs
@@ -74,6 +74,7 @@ namespace Assets.Scripts.EscapeMenu.Interfaces
                 UnityEngine.Debug.Log($"The setting {setting} changed");
             });
             DataTracker.Current.EventManager.EscapeMenuRequested.AddListener(Toggle);
+            DataTracker.Current.EventManager.EscapeMenuCloseRequested.AddListener(Hide);
         }
 
         /// <summary>

--- a/4900Project/Assets/Scripts/Events/EventManager.cs
+++ b/4900Project/Assets/Scripts/Events/EventManager.cs
@@ -83,6 +83,7 @@ namespace SIEvents
 
         //=== Escape Menu ===========================================//
         public UnityEvent EscapeMenuRequested = new UnityEvent();
+        public UnityEvent EscapeMenuCloseRequested = new UnityEvent();
         public UnityEvent OnCreditsButtonClicked = new UnityEvent();
 
         //=== Settings ==============================================//

--- a/4900Project/Assets/Scripts/Quests/QuestJournalWindow.cs
+++ b/4900Project/Assets/Scripts/Quests/QuestJournalWindow.cs
@@ -30,7 +30,8 @@ public class QuestJournalWindow : MonoBehaviour
 
     void OnEnable()
     {
-        
+        Clear();
+
         // Grab text fields from SceneGraph (THESE ARE Erroneous. too ambigious)
         NameField = GameObject.Find("Quest Name").GetComponent<UnityEngine.UI.Text>();
         NameField.text = "";
@@ -128,14 +129,27 @@ public class QuestJournalWindow : MonoBehaviour
     {
         EventManager.Instance.UnfreezeMap.Invoke();
         transform.parent.gameObject.SetActive(false);
-        GameObject.Destroy(completedToggleButton);
-        GameObject.Destroy(activeToggleButton);
-        foreach(GameObject Item in activeQuestItems)
+    }
+
+    /// <summary>
+    /// Destroys all existing game objects. Clears the UI.
+    /// </summary>
+    protected void Clear()
+    {
+        if (completedToggleButton != null)
+        {
+            GameObject.Destroy(completedToggleButton);
+        }
+        if (activeToggleButton != null)
+        {
+            GameObject.Destroy(activeToggleButton);
+        }
+        foreach (GameObject Item in activeQuestItems)
         {
             Destroy(Item);
         }
         activeQuestItems = new List<GameObject>();
-        foreach(GameObject Item in completedQuestItems)
+        foreach (GameObject Item in completedQuestItems)
         {
             Destroy(Item);
         }


### PR DESCRIPTION
## What am I addressing?
Closes #307 

## How/Why did I address it?
When one window opens up from the HUD, the active window closes. Only one window will stay open at any given time. Players are still able to switch between them.

## Reviewers
@GameDevProject-S20/bestteam

### What should reviewers focus on?
- [x] Toggle between the three buttons in the HUD
- [x] Verify that when an interface is already open, opening another interface will show that new interface as the active window
- [x] Verify that when the player clicks the same interface button multiple times, the interface stays open

## Comments & Concerns 

