### PR TITLE
Fix Dialogue text animation

### DIFF
--- a/4900Project/Assets/Scripts/Dialogue/Frontend/UIControl.cs
+++ b/4900Project/Assets/Scripts/Dialogue/Frontend/UIControl.cs
@@ -193,10 +193,8 @@ namespace Assets.Scripts.Dialogue.Frontend
                 textMeshPro.text = "";
             }
 
-            // Resize the content based on what's already in the text
-            UpdatePageScrolling();
-
             textMeshPro.text = nextPageText;
+            UpdatePageScrolling();
             StartCoroutine(UpdatePage(currentPage.Buttons));
         }
 
@@ -260,11 +258,11 @@ namespace Assets.Scripts.Dialogue.Frontend
             }
             else
             {
-                // Based on that, we need to decide on alignment & positioning of the text.
-                // If we don't yet have a full Dialogue, we want everything displaying to the bottom (in which case we need to position it to the bottom);
-                //  otherwise, we want it to be displaying from the top, so that everything will be displayed. In this case, it positions to the top.
-                var alignment = (textHeight < scrollHeight) ? TextAlignmentOptions.Bottom : TextAlignmentOptions.Top;
-                var textPosition = (textHeight < scrollHeight) ? -scrollHeight : 0;
+                // The height of the Dialogue is determined by whether or not we have started scrolling yet.
+                // If textHeight >= scrollingHeight, then text is scrolling & we need to determine the size by -textHeight.
+                // Otherwise, if scrollHeight > textHeight, scrolling hasn't started yet & the size is determined by the height of the scroll box.
+                var alignment = TextAlignmentOptions.Bottom;
+                var textPosition = (textHeight < scrollHeight) ? -scrollHeight : -textHeight;
 
                 // Now that we have the variables stored, we can just go through and update:
                 // The contentRect displays the content of the frame. It needs to be sized to newHeight.


### PR DESCRIPTION
## What am I addressing?
No ticket assigned with this one, but it fixes an issue we encountered in the playtest with Dialogue scrolling.
When the player was given the scrollbar on Dialogue, text was appearing below the textbox, making it delay & not show the animation.

## How/Why did I address it?
I found the issue, it had to do with the height being calculated incorrectly. That's fixed & the animation now smoothly runs whether the scroll bar is showing or not.

## Reviewers
@GameDevProject-S20/bestteam

### What should reviewers focus on?
- [x] Find an encounter that requires more than one full page of text
- [x] Proceed to further pages in the Dialogue, verify that the animation runs smoothly

## Comments & Concerns 

