### PR TITLE
Dialogue Bug Fix

### DIFF
--- a/4900Project/Assets/Scripts/Dialogue/Frontend/UIControl.cs
+++ b/4900Project/Assets/Scripts/Dialogue/Frontend/UIControl.cs
@@ -214,7 +214,9 @@ namespace Assets.Scripts.Dialogue.Frontend
         protected IEnumerator PlayTextTypingAnimation()
         {
             var textMeshPro = textDisplay.GetComponent<TextMeshProUGUI>();
-            int charCount = System.Text.RegularExpressions.Regex.Replace(textMeshPro.text, "<.*?>", String.Empty).Length;
+            textMeshPro.ForceMeshUpdate();
+
+            int charCount = textMeshPro.textInfo.characterCount;
             for (var i = textMeshPro.maxVisibleCharacters; i < charCount; i++)
             {
                 textMeshPro.maxVisibleCharacters = i;


### PR DESCRIPTION
## What am I addressing?
Closes #332 

## How/Why did I address it?
Originally the number of characters in text was being counted by a regular expression that stripped out tags and counted the number of characters not in tags.
TextMeshPro has its own property to return the number of characters in text (TextInfo.CharacterCount), I'm not sure if this one strips out tags but from my testing it looks like it's giving the right values.
Tested specifically with the encounter that was giving the issue and the character count was correct.

## Reviewers
@GameDevProject-S20/bestteam

### What should reviewers focus on?
- [ ] Run through fixed/random encounters
- [ ] Verify that the text typing animation displays correctly, doesn't hang, and shows all the text

## Comments & Concerns 

